### PR TITLE
Optionally filter jobs by node

### DIFF
--- a/lib/oban_web/live/dashboard_live.ex
+++ b/lib/oban_web/live/dashboard_live.ex
@@ -8,8 +8,15 @@ defmodule ObanWeb.DashboardLive do
 
   @tick_timing 500
   @flash_timing 5_000
-  @default_filters %{page: 1, limit: 30, queue: "any", state: "executing", terms: nil}
   @default_flash %{show: false, mode: :success, message: ""}
+  @default_filters %{
+    page: 1,
+    limit: 30,
+    node: "any",
+    queue: "any",
+    state: "executing",
+    terms: nil
+  }
 
   def render(assigns) do
     DashboardView.render("index.html", assigns)
@@ -51,6 +58,13 @@ defmodule ObanWeb.DashboardLive do
     flash = Map.put(assigns.flash, :show, false)
 
     {:noreply, assign(socket, flash: flash)}
+  end
+
+  def handle_event("change_node", %{"node" => node}, %{assigns: assigns} = socket) do
+    filters = Map.put(assigns.filters, :node, node)
+    jobs = Query.jobs(assigns.config.repo, filters)
+
+    {:noreply, assign(socket, jobs: jobs, filters: filters)}
   end
 
   def handle_event("change_queue", %{"queue" => queue}, %{assigns: assigns} = socket) do

--- a/lib/oban_web/templates/dashboard/_nodes.html.eex
+++ b/lib/oban_web/templates/dashboard/_nodes.html.eex
@@ -6,7 +6,9 @@
   <hr class="flat" />
   <ul class="menu-list">
     <%= for {node, count} <- @node_counts do %>
-      <li class="menu-item flex">
+      <li class="menu-item <%= if node == @node do %>menu-item--active<% end %> flex"
+          phx-click="change_node"
+          phx-value-node="<%= node %>">
         <button class="menu-btn"><%= truncate(node, 0..30) %></button>
         <span class="menu-cnt"><%= integer_to_delimited(count) %></span>
       </li>

--- a/lib/oban_web/templates/dashboard/index.html.leex
+++ b/lib/oban_web/templates/dashboard/index.html.leex
@@ -2,7 +2,7 @@
 
 <section class="flex">
   <div class="sidebar sidebar--filters">
-    <%= render("_nodes.html", node_counts: @node_counts) %>
+    <%= render("_nodes.html", node: @filters.node, node_counts: @node_counts) %>
     <%= render("_states.html", state: @filters.state, state_counts: @state_counts) %>
     <%= render("_queues.html", queue: @filters.queue, queue_counts: @queue_counts) %>
   </div>

--- a/test/oban_web/live/dashboard_live_test.exs
+++ b/test/oban_web/live/dashboard_live_test.exs
@@ -70,6 +70,29 @@ defmodule ObanWeb.DashboardLiveTest do
     end
   end
 
+  test "filtering jobs by node", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/oban")
+
+    web_1 = ["web.1", "alpha", "aaaaaaaa"]
+    web_2 = ["web.2", "alpha", "aaaaaaaa"]
+
+    insert_job!([ref: 1], queue: "alpha", worker: AlphaWorker, attempted_by: web_1)
+    insert_job!([ref: 2], queue: "alpha", worker: DeltaWorker, attempted_by: web_2)
+    insert_job!([ref: 3], queue: "alpha", worker: GammaWorker, attempted_by: web_1)
+
+    html = render_click(view, :change_state, %{"state" => "available"})
+
+    assert html =~ "AlphaWorker"
+    assert html =~ "DeltaWorker"
+    assert html =~ "GammaWorker"
+
+    html = render_click(view, :change_node, %{"node" => "web.2"})
+
+    refute html =~ "AlphaWorker"
+    assert html =~ "DeltaWorker"
+    refute html =~ "GammaWorker"
+  end
+
   test "filtering jobs by queue", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/oban")
 


### PR DESCRIPTION
Jobs have a three element column called `attempted_by`, where the first field is the name of the node that attempted to run them. This makes jobs filterable by clicking on the node list, just like queues and states.

There isn't an index backing this filter, so it may be slow in a view with hundreds of thousands of jobs (i.e. completed).

Closes #16