### PR TITLE
Only show Pro version number when available

### DIFF
--- a/lib/oban/web/components/layouts.ex
+++ b/lib/oban/web/components/layouts.ex
@@ -171,14 +171,14 @@ defmodule Oban.Web.Layouts do
 
     ~H"""
     <footer class="flex flex-col px-3 py-6 text-sm justify-center items-center md:flex-row">
-      <span :if={@oss_version} class="text-gray-600 dark:text-gray-400 tabular mr-0 mb-1 md:mr-3 md:mb-0">
+      <span class="text-gray-600 dark:text-gray-400 tabular mr-0 mb-1 md:mr-3 md:mb-0">
         Oban v{@oss_version}
       </span>
       <span class="text-gray-600 dark:text-gray-400 tabular mr-0 mb-1 md:mr-3 md:mb-0">
         Oban.Web v{@web_version}
       </span>
-      <span :if={@pro_version} class="text-gray-600 dark:text-gray-400 tabular mr-0 mb-3 md:mr-3 md:mb-0">
-        Oban.Pro v{@pro_version}
+      <span class="text-gray-600 dark:text-gray-400 tabular mr-0 mb-3 md:mr-3 md:mb-0">
+        Oban.Pro {if @pro_version, do: "v#{@pro_version}", else: "–"}
       </span>
 
       <span class="text-gray-800 dark:text-gray-200 mr-0.5 pt-1">

--- a/lib/oban/web/components/layouts.ex
+++ b/lib/oban/web/components/layouts.ex
@@ -164,21 +164,21 @@ defmodule Oban.Web.Layouts do
   def footer(assigns) do
     assigns =
       assign(assigns,
-        oss_version: "Oban v#{Application.spec(:oban, :vsn)}",
-        web_version: "Oban.Web v#{Application.spec(:oban_web, :vsn)}",
-        pro_version: "Oban.Pro v#{Application.spec(:oban_pro, :vsn)}"
+        oss_version: Application.spec(:oban, :vsn),
+        web_version: Application.spec(:oban_web, :vsn),
+        pro_version: Application.spec(:oban_pro, :vsn)
       )
 
     ~H"""
     <footer class="flex flex-col px-3 py-6 text-sm justify-center items-center md:flex-row">
-      <span class="text-gray-600 dark:text-gray-400 tabular mr-0 mb-1 md:mr-3 md:mb-0">
-        {@oss_version}
+      <span :if={@oss_version} class="text-gray-600 dark:text-gray-400 tabular mr-0 mb-1 md:mr-3 md:mb-0">
+        Oban v{@oss_version}
       </span>
       <span class="text-gray-600 dark:text-gray-400 tabular mr-0 mb-1 md:mr-3 md:mb-0">
-        {@web_version}
+        Oban.Web v{@web_version}
       </span>
-      <span class="text-gray-600 dark:text-gray-400 tabular mr-0 mb-3 md:mr-3 md:mb-0">
-        {@pro_version}
+      <span :if={@pro_version} class="text-gray-600 dark:text-gray-400 tabular mr-0 mb-3 md:mr-3 md:mb-0">
+        Oban.Pro v{@pro_version}
       </span>
 
       <span class="text-gray-800 dark:text-gray-200 mr-0.5 pt-1">


### PR DESCRIPTION
Hey, thank you so much for open sourcing the Dashboard! It's amazing!

I just noticed that the footer shows the Oban.Pro version but it's not available (not yet using it)

![image](https://github.com/user-attachments/assets/5740cf79-ebde-4020-bb7e-340b12f54087)

This fixes the footer to only show the Pro version when it's available and streamlines the string interpolation

![image](https://github.com/user-attachments/assets/21f76ec4-c1c9-4756-849e-518db9d12881)
