### PR TITLE
Replace inline styles with tailwind classes

### DIFF
--- a/lib/oban/web/components/layouts.ex
+++ b/lib/oban/web/components/layouts.ex
@@ -29,7 +29,7 @@ defmodule Oban.Web.Layouts do
           fill="currentColor"
           fill-rule="nonzero"
         />
-        <g fill="none" fill-rule="evenodd" style="filter: drop-shadow(0 2px 3px rgb(0 0 0 / 0.3))">
+        <g fill="none" fill-rule="evenodd" class="drop-shadow-md/30">
           <path fill="#EBECFB" d="M57.95 21.249 54.623 9.372 42.746 6.045l4.453 10.751z" /><path
             fill="#C5B0DF"
             d="m53.497 31.999-6.298-15.203 10.751 4.453z"

--- a/lib/oban/web/live/jobs/chart_component.ex
+++ b/lib/oban/web/live/jobs/chart_component.ex
@@ -127,8 +127,7 @@ defmodule Oban.Web.Jobs.ChartComponent do
 
       <div
         id="chart"
-        class={["w-full relative cursor-crosshair pl-5 pr-3", unless(@visible, do: "hidden")]}
-        style="height: 200px;"
+        class={["w-full relative cursor-crosshair pl-5 pr-3 h-200px", unless(@visible, do: "hidden")]}
       >
         <canvas id="chart-canvas" phx-update="ignore" phx-hook="Charter"></canvas>
       </div>


### PR DESCRIPTION
In order to reduce the number of content security policy errors observed in the browser console, replace non-nonced inline styles with their equivalent tailwind classes.

I don't have an oban pro key so I can't run the test suite locally, but in both cases the tailwind style seems like a near-perfect replacement for the original code.