### PR TITLE
Do not include test files in release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Oban.Web.MixProject do
     [
       maintainers: ["Parker Selbert"],
       licenses: ["Apache-2.0"],
-      files: ~w(lib priv .formatter.exs mix.exs README* CHANGELOG* LICENSE*),
+      files: ~w(lib priv/static* .formatter.exs mix.exs README* CHANGELOG* LICENSE*),
       links: %{
         Website: "https://oban.pro",
         Changelog: "#{@source_url}/blob/main/CHANGELOG.md",


### PR DESCRIPTION
The latest release, `oban_web 2.11.4`, includes some files larger than 1 MB that are not actually needed; these are mostly testing files.

```console
$ mix hex.package fetch oban_web --unpack
oban_web v2.11.4 extracted to /private/tmp/oban_web-2.11.4
$ tree oban_web-2.11.4/
oban_web-2.11.4/
...
├── mix.exs
├── priv
│   ├── oban_web_test.db
│   ├── oban_web_test.db-shm
│   ├── oban_web_test.db-wal
│   └── static
│       ├── app.css
│       └── app.js
└── README.md

17 directories, 53 files
````

With this change, we should avoid that situation in the future:

```console
$ mix hex.build --unpack
...
  Files:
    ...
    lib/oban/web/exceptions.ex
    lib/oban/web.ex
    priv/static
    priv/static/app.css
    .formatter.exs
    mix.exs
    README.md
    CHANGELOG.md
    LICENSE.txt
  Version: 2.11.4
  Build tools: mix
  Description: Dashboard for the Oban job processing framework
  Licenses: Apache-2.0
  Links:
    Website: https://oban.pro
    Changelog: https://github.com/oban-bg/oban_web/blob/main/CHANGELOG.md
    GitHub: https://github.com/oban-bg/oban_web
  Elixir: ~> 1.15
Saved to oban_web-2.11.4
```