### PR TITLE
Ensure the resolver moduler is loaded

### DIFF
--- a/lib/oban/web/resolver.ex
+++ b/lib/oban/web/resolver.ex
@@ -431,7 +431,12 @@ defmodule Oban.Web.Resolver do
 
   @doc false
   def call_with_fallback(resolver, fun, args) when is_atom(fun) and is_list(args) do
-    resolver = if Code.ensure_loaded(resolver) && function_exported?(resolver, fun, length(args)), do: resolver, else: __MODULE__
+    resolver =
+      if Code.ensure_loaded(resolver) and function_exported?(resolver, fun, length(args))
+        resolver
+      else
+        __MODULE__
+      end
 
     apply(resolver, fun, args)
   end


### PR DESCRIPTION
Due to how the resolver is defined, it won't be automatically loaded locally by Elixir (unless eager module loading is turned on). 

So we need to ensure that the resolver is loaded before checking if the function is exported.

Fixes https://github.com/oban-bg/oban_web/issues/134