### PR TITLE
Add custom dark mode variant

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -91,6 +91,10 @@ select:-moz-focusring {
 /* Tailwind */
 
 @import "tailwindcss";
+
+/* Custom dark mode variant using .dark class selector for class-based dark mode toggling - see https://tailwindcss.com/docs/dark-mode */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @plugin "@tailwindcss/forms";
 
 @source "../../lib/**/*.*ex";


### PR DESCRIPTION
Enable class-based dark mode using the `.dark` selector. Allows toggling dark mode via CSS class instead of system preferences.

Usage: Use `dark:` prefix on utility classes (e.g., dark:bg-gray-900). Toggle by adding/removing `.dark` class on a parent element. See details [here](https://tailwindcss.com/docs/dark-mode).