### PR TITLE
fix: add nil check to table component timestamp helper

### DIFF
--- a/lib/oban/web/live/jobs/table_component.ex
+++ b/lib/oban/web/live/jobs/table_component.ex
@@ -207,7 +207,9 @@ defmodule Oban.Web.Jobs.TableComponent do
         "scheduled" -> job.scheduled_at
       end
 
-    DateTime.to_unix(datetime, :millisecond)
+    if not is_nil(datetime) do
+      DateTime.to_unix(datetime, :millisecond)
+    end
   end
 
   defp relative_mode(job) do


### PR DESCRIPTION
We're seeing the following error:

```
#PID<0.1254378.0> running CozyProxy.Dispatcher (connection #PID<0.1253425.0>, stream id 13) terminated
Server: XXX:443 (https)
Request: GET /jobs/jobs?state=cancelled
** (exit) an exception was raised:
    ** (FunctionClauseError) no function clause matching in DateTime.to_unix/2
        (elixir 1.18.1) lib/calendar/datetime.ex:908: DateTime.to_unix(nil, :millisecond)
        (oban_web 2.11.6) lib/oban/web/live/jobs/table_component.ex:133: anonymous fn/3 in Oban.Web.Jobs.TableComponent.job_row/1
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:420: Phoenix.LiveView.Diff.traverse/6
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:609: anonymous fn/3 in Phoenix.LiveView.Diff.traverse_dynamic/6
        (elixir 1.18.1) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:419: Phoenix.LiveView.Diff.traverse/6
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:609: anonymous fn/3 in Phoenix.LiveView.Diff.traverse_dynamic/6
        (elixir 1.18.1) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:419: Phoenix.LiveView.Diff.traverse/6
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:609: anonymous fn/3 in Phoenix.LiveView.Diff.traverse_dynamic/6
        (elixir 1.18.1) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:728: Phoenix.LiveView.Diff.process_keyed/5
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:665: anonymous fn/6 in Phoenix.LiveView.Diff.traverse_keyed/8
        (elixir 1.18.1) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:646: Phoenix.LiveView.Diff.traverse_keyed/8
        (phoenix_live_view 1.1.17) lib/phoenix_live_view/diff.ex:548: Phoenix.LiveView.Diff.traverse/6
```

Because one of our cancelled jobs is missing the `cancelled_at` timestamp.