### PR TITLE
Handle limit - local_limit diffs

### DIFF
--- a/lib/oban/web/live/queues/detail_component.ex
+++ b/lib/oban/web/live/queues/detail_component.ex
@@ -612,7 +612,7 @@ defmodule Oban.Web.Queues.DetailComponent do
 
   defp local_limit(checks) do
     checks
-    |> Enum.map(& &1["local_limit"])
+    |> Enum.map(&((&1["limit"] || &1["local_limit"])))
     |> Enum.max()
   end
 

--- a/lib/oban/web/live/queues/detail_instance_component.ex
+++ b/lib/oban/web/live/queues/detail_instance_component.ex
@@ -16,7 +16,7 @@ defmodule Oban.Web.Queues.DetailInsanceComponent do
       |> assign(access: assigns.access, checks: assigns.checks)
       |> assign_new(:queue, fn -> assigns.checks["queue"] end)
       |> assign_new(:paused, fn -> assigns.checks["paused"] end)
-      |> assign_new(:local_limit, fn -> assigns.checks["local_limit"] end)
+      |> assign_new(:local_limit, fn -> assigns.checks["limit"] || assigns.checks["local_limit"] end)
 
     {:ok, socket}
   end

--- a/lib/oban/web/live/queues/table_component.ex
+++ b/lib/oban/web/live/queues/table_component.ex
@@ -153,7 +153,7 @@ defmodule Oban.Web.Queues.TableComponent do
 
   defp local_limit(queue) do
     queue.checks
-    |> Enum.map(& &1["local_limit"])
+    |> Enum.map(&((&1["limit"] || &1["local_limit"])))
     |> Enum.min_max()
     |> case do
       {min, min} -> min


### PR DESCRIPTION
OSS Oban uses limit key (while pro uses local_limit) which is not being handled in some views leading to missing data in the UI.