### PR TITLE
FIX: Escape regex match in highlight function to prevent errors

### DIFF
--- a/lib/oban/web/live/search_component.ex
+++ b/lib/oban/web/live/search_component.ex
@@ -196,7 +196,7 @@ defmodule Oban.Web.SearchComponent do
       |> List.last()
 
     if is_binary(value) and is_binary(match) do
-      pattern = Regex.compile!("(#{match})", "i")
+      pattern = Regex.compile!("(#{Regex.escape(match)})", "i")
 
       value
       |> String.replace(pattern, "<b>\\1</b>")


### PR DESCRIPTION
### **Error**

<img width="298" height="70" alt="image" src="https://github.com/user-attachments/assets/b61d6fa7-1a82-4139-af66-e4b687b8c70a" />

### **How to reproduce:**

1. Go to the Oban Web dashboard
2. Click on the search/filter input
3. Type args:args[ (or any filter ending with an unmatched [)
4. The Regex.CompileError is raised because [ starts a character class in regex that's never closed

<img width="1792" height="965" alt="image" src="https://github.com/user-attachments/assets/68c4b48b-1f37-4085-96fc-32542a93ff6a" />

### **Fix**
  * Updated the regex pattern used for highlighting matches in the search component to use `Regex.escape`, preventing issues when the search term contains special characters. This change makes the search highlighting more robust and secure.