### PR TITLE
Fix clearing tags from edit forms

### DIFF
--- a/lib/oban/web/live/crons/detail_component.ex
+++ b/lib/oban/web/live/crons/detail_component.ex
@@ -423,7 +423,7 @@ defmodule Oban.Web.Crons.DetailComponent do
       priority: new_val?(parse_int(params["priority"]), get_opt(cron, "priority")),
       max_attempts: new_val?(parse_int(params["max_attempts"]), get_opt(cron, "max_attempts")),
       guaranteed: new_val?(params["guaranteed"] == "true", get_opt(cron, "guaranteed") == true),
-      tags: new_val?(parse_tags(params["tags"]), get_opt(cron, "tags")),
+      tags: new_val?(parse_form_tags(params), get_opt(cron, "tags")),
       args: new_val?(parse_json(params["args"]), get_opt(cron, "args"))
     ]
   end
@@ -434,6 +434,9 @@ defmodule Oban.Web.Crons.DetailComponent do
   defp new_val?(val, val, _default), do: nil
   defp new_val?(val, nil, val), do: nil
   defp new_val?(val, _current, _default), do: val
+
+  defp parse_form_tags(%{"tags" => tags}), do: parse_tags(tags) || []
+  defp parse_form_tags(_params), do: nil
 
   defp get_opt(%{opts: opts}, key) do
     Map.get(opts, key)

--- a/lib/oban/web/live/jobs/detail_component.ex
+++ b/lib/oban/web/live/jobs/detail_component.ex
@@ -1021,7 +1021,7 @@ defmodule Oban.Web.Jobs.DetailComponent do
       priority: new_val?(parse_int(params["priority"]), job.priority),
       max_attempts: new_val?(parse_int(params["max_attempts"]), job.max_attempts),
       scheduled_at: new_val?(parse_datetime(params["scheduled_at"]), job.scheduled_at),
-      tags: new_val?(parse_tags(params["tags"]), job.tags),
+      tags: new_val?(parse_edit_tags(params), job.tags),
       args: new_val?(parse_json(params["args"]), job.args)
     ]
   end
@@ -1030,6 +1030,9 @@ defmodule Oban.Web.Jobs.DetailComponent do
   defp new_val?("", _current), do: nil
   defp new_val?(val, val), do: nil
   defp new_val?(val, _current), do: val
+
+  defp parse_edit_tags(%{"tags" => tags}), do: parse_tags(tags) || []
+  defp parse_edit_tags(_params), do: nil
 
   defp parse_datetime(nil), do: nil
   defp parse_datetime(""), do: nil

--- a/test/oban/web/pages/crons/detail_test.exs
+++ b/test/oban/web/pages/crons/detail_test.exs
@@ -235,6 +235,27 @@ defmodule Oban.Web.Pages.Crons.DetailTest do
       assert entry.opts["args"] == %{"mode" => "full", "limit" => 100}
       assert entry.opts["guaranteed"] == true
     end
+
+    test "removing all dynamic cron tags" do
+      DynamicCron.insert([
+        {"0 * * * *", DetailCronWorker, name: "clear-tags-cron", tags: ["important", "nightly"]}
+      ])
+
+      {:ok, live, _html} = live(build_conn(), "/oban/crons/clear-tags-cron")
+
+      live
+      |> form("#cron-form", %{"tags" => ""})
+      |> render_change()
+
+      assert has_element?(live, ~s|#cron-form button[type="submit"]:not([disabled])|)
+
+      live
+      |> form("#cron-form", %{"tags" => ""})
+      |> render_submit()
+
+      assert [entry] = Enum.filter(DynamicCron.all(), &(&1.name == "clear-tags-cron"))
+      assert entry.opts["tags"] == []
+    end
   end
 
   defp refresh(live) do

--- a/test/oban/web/pages/jobs/detail_test.exs
+++ b/test/oban/web/pages/jobs/detail_test.exs
@@ -115,6 +115,32 @@ defmodule Oban.Web.Pages.Jobs.DetailTest do
       assert render(live) =~ "Job updated successfully"
     end
 
+    test "removing all job tags", %{live: live} do
+      job =
+        insert_job!([ref: 1],
+          state: "available",
+          worker: WorkerA,
+          tags: ["alpha", "beta"]
+        )
+
+      open_state(live, "available")
+      open_details(live, job)
+
+      live
+      |> form("#job-edit-form", %{"tags" => ""})
+      |> render_change()
+
+      assert has_element?(live, ~s|#job-edit-form button[type="submit"]:not([disabled])|)
+
+      live
+      |> form("#job-edit-form", %{"tags" => ""})
+      |> render_submit()
+
+      with_backoff(fn ->
+        assert %{tags: []} = Repo.reload!(job)
+      end)
+    end
+
     test "read-only users cannot submit edits or rewrite the worker" do
       job = insert_job!([ref: 1], state: "available", worker: WorkerA)
 


### PR DESCRIPTION
## Summary

- Treat blank tag input as an empty tag list when editing jobs
- Apply the same behavior to dynamic cron editing
- Add regression coverage for clearing all tags from job and cron edit forms

## Testing

- `mix test test/oban/web/pages/jobs/detail_test.exs test/oban/web/pages/crons/detail_test.exs --max-cases 1`
