### PR TITLE
Add partial-index predicate to sub-workflow parent dep subquery

### DIFF
--- a/lib/oban/web/queries/workflow_query.ex
+++ b/lib/oban/web/queries/workflow_query.ex
@@ -133,7 +133,8 @@ defmodule Oban.Web.WorkflowQuery do
         (SELECT dep->>1
          FROM ?.oban_jobs j2,
               LATERAL jsonb_array_elements(j2.meta->'deps') AS dep
-         WHERE j2.meta->>'workflow_id' = ?
+         WHERE j2.meta \\? 'workflow_id'
+           AND j2.meta->>'workflow_id' = ?
            AND jsonb_typeof(dep) = 'array'
            AND dep->>0 = ?
          LIMIT 1)

--- a/test/oban/web/queries/workflow_query_test.exs
+++ b/test/oban/web/queries/workflow_query_test.exs
@@ -98,6 +98,86 @@ defmodule Oban.Web.Repo.WorkflowQueryTest do
     end
   end
 
+  describe "get_workflow_graph/3 sub-workflow parent deps" do
+    test "resolves parent_dep for every sub-workflow", %{conf: conf} do
+      insert_job!(%{}, conf: conf, meta: %{workflow_id: "parent", name: "step-a"})
+      insert_job!(%{}, conf: conf, meta: %{workflow_id: "parent", name: "step-b"})
+
+      for {sub, dep} <- [{"sub-1", "step-a"}, {"sub-2", "step-b"}] do
+        insert_job!(%{},
+          conf: conf,
+          meta: %{
+            workflow_id: sub,
+            sup_workflow_id: "parent",
+            name: "#{sub}-step",
+            deps: [["parent", dep]]
+          }
+        )
+      end
+
+      insert_job!(%{},
+        conf: conf,
+        meta: %{workflow_id: "sub-3", sup_workflow_id: "parent", name: "no-dep"}
+      )
+
+      %{sub_workflows: subs} = WorkflowQuery.get_workflow_graph(conf, "parent")
+
+      assert [{"sub-1", "step-a"}, {"sub-2", "step-b"}, {"sub-3", nil}] ==
+               subs |> Enum.map(&{&1.workflow_id, &1.parent_dep}) |> Enum.sort()
+    end
+
+    test "parent dep subquery uses the partial workflow index", %{conf: conf} do
+      insert_job!(%{},
+        conf: conf,
+        meta: %{workflow_id: "sub", sup_workflow_id: "parent", deps: [["parent", "step"]]}
+      )
+
+      {sql, params} = capture_query(fn -> WorkflowQuery.get_workflow_graph(conf, "parent") end)
+
+      plan =
+        conf.repo.transaction(fn ->
+          conf.repo.query!("SET LOCAL enable_seqscan = off")
+          conf.repo.query!("EXPLAIN " <> sql, params).rows
+        end)
+        |> elem(1)
+        |> List.flatten()
+        |> Enum.join("\n")
+
+      assert plan =~ "Index Scan using oban_jobs_workflow_index"
+      refute plan =~ "Seq Scan on oban_jobs j2"
+    end
+  end
+
+  # Captures the SQL and params of the sub-workflow graph query via Ecto telemetry.
+  defp capture_query(fun) do
+    event = [:oban, :web, :repo, :query]
+    pid = self()
+
+    :telemetry.attach(
+      {__MODULE__, event},
+      event,
+      fn _event, _measure, %{query: query, params: params}, _ ->
+        send(pid, {:query, query, params})
+      end,
+      nil
+    )
+
+    fun.()
+
+    receive_graph_query()
+  after
+    :telemetry.detach({__MODULE__, [:oban, :web, :repo, :query]})
+  end
+
+  defp receive_graph_query do
+    receive do
+      {:query, query, params} ->
+        if query =~ "jsonb_array_elements", do: {query, params}, else: receive_graph_query()
+    after
+      0 -> flunk("sub-workflow graph query was not executed")
+    end
+  end
+
   describe "get_sub_workflows/3" do
     test "returns sub-workflows for a parent workflow", %{conf: conf} do
       insert_workflow!(conf, "parent-wf", name: "parent", worker: "ParentWorker")


### PR DESCRIPTION
Improve one of the queries that get frequently invoked when opening the Oban Web workflow details view. It currently cannot use the `oban_jobs_workflow_index`; this fixes that.

Resolves #193 